### PR TITLE
fixed button_to into link_to

### DIFF
--- a/app/views/shared/_membershipcard.html.erb
+++ b/app/views/shared/_membershipcard.html.erb
@@ -35,7 +35,7 @@
   <div class="profile-info">
     <% if authenticated? %>
       <% if current_user.role.in?(["admin", "godmode", "volunteer"]) %>
-        <%= button_to "Dashboard Administrateur", admin_dashboard_path, class: "white-button" %>
+        <%= link_to "Dashboard Administrateur", admin_dashboard_path, class: "white-button" %>
       <% end %>
     <% end %>
     


### PR DESCRIPTION
There was an error in the profile of an admin to access the dashboard, when trying to get to another page you should use link_to istead of button_to, button_to should only be used to send requests that are not GET