### PR TITLE
Dashboard admin fixed for new user last name and first name Nil

### DIFF
--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -3,7 +3,11 @@
 <div class="container mx-auto px-4 py-6 max-w-7xl">
     <div class="bg-gradient-to-r from-[#1F5C55] to-teal-600 rounded-lg shadow-lg mb-8 p-6 text-white">
         <h1 class="text-3xl font-bold text-center mb-2">Tableau de bord administrateur</h1>
-        <p class="text-center text-white/80">Bienvenue, <%= Current.user.first_name %> <%= Current.user.last_name %></p>
+            <% if Current.user && (Current.user.first_name || Current.user.last_name) %>
+                <p class="text-center text-white/80">
+                    Bienvenue, <%= Current.user.first_name %> <%= Current.user.last_name %>
+                </p>
+            <% end %>
     </div>
 
     <!-- Statistiques principales -->
@@ -144,19 +148,22 @@
                 <div class="overflow-y-auto max-h-[400px]">
                     <ul class="divide-y divide-gray-200">
                         <% User.order(created_at: :desc).limit(5).each do |user| %>
-                            <li class="p-4 hover:bg-gray-50">
-                                <div class="flex items-center">
-                                    <div class="flex-shrink-0 h-10 w-10 rounded-full bg-[#1F5C55]/10 flex items-center justify-center">
-                                        <span class="text-[#1F5C55] font-medium"><%= "#{user.first_name.first}#{user.last_name.first}" %></span>
-                                    </div>
-                                    <div class="ml-4">
-                                        <p class="text-sm font-medium text-gray-900">Nouvel utilisateur : <%= user.first_name %> <%= user.last_name %></p>
-                                        <p class="text-xs text-gray-500"><%= time_ago_in_words(user.created_at) %></p>
-                                    </div>
-                                </div>
-                            </li>
+                        <li class="p-4 hover:bg-gray-50">
+                            <div class="flex items-center">
+                            <div class="flex-shrink-0 h-10 w-10 rounded-full bg-[#1F5C55]/10 flex items-center justify-center">
+                                <span class="text-[#1F5C55] font-medium">
+                                <%= "#{user.first_name&.first}#{user.last_name&.first}".strip.presence || "?" %>
+                                </span>
+                            </div>
+                            <div class="ml-4">
+                                <p class="text-sm font-medium text-gray-900">
+                                Nouvel utilisateur : <%= [user.first_name, user.last_name].compact.join(" ") %>
+                                </p>
+                                <p class="text-xs text-gray-500"><%= time_ago_in_words(user.created_at) %></p>
+                            </div>
+                            </div>
+                        </li>
                         <% end %>
-                        
                         <% Event.order(created_at: :desc).limit(3).each do |event| %>
                             <li class="p-4 hover:bg-gray-50">
                                 <div class="flex items-center">


### PR DESCRIPTION
Fixed of the admin dashboard index , when we sign up from outside the website and then an admin connect and open his dashboard , it was breaking down because of no option for the dashboard to show the user_firstname and lastname without it mentioned in the sign up form .... 

adding condiotional to avoid the breakdown 