### PR TITLE
fix: add packages write permission for GHCR

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ staging ]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest

--- a/.github/workflows/05-prod-deploy.yml
+++ b/.github/workflows/05-prod-deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   deploy-production:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add missing `packages: write` permission to deployment workflows to fix the 'installation not allowed to Write organization package' error.