### PR TITLE
fix: GHCR authentication with fallback token

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         
     - name: Build Docker image for staging
       run: |

--- a/.github/workflows/05-prod-deploy.yml
+++ b/.github/workflows/05-prod-deploy.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         
     - name: Build Docker image for production
       run: |


### PR DESCRIPTION
Add GHCR_TOKEN fallback for package registry authentication. This should fix the 'denied: installation not allowed to Write organization package' error now that repository has write access to the package.