### PR TITLE
feat: optimize Kamal configs for VPS M

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -11,39 +11,61 @@ ssh:
   user: deploy
   key: <%= ENV['SSH_PRIVATE_KEY'] %>
 
-# Port standard pour production
-port: 80
+# Port production (différent de staging)
+port: 3000
+
+# Credentials for your image host
+registry:
+  server: ghcr.io
+  username: LeCircographe-asso
+  password:
+    - KAMAL_REGISTRY_PASSWORD
 
 # Variables d'environnement production
 env:
-  RAILS_ENV: production
-  PRODUCTION_MODE: true
-  RAILS_SERVE_STATIC_FILES: true
+  secret:
+    - RAILS_MASTER_KEY
+  clear:
+    RAILS_ENV: production
+    PRODUCTION_MODE: true
+    RAILS_SERVE_STATIC_FILES: true
+    SOLID_QUEUE_IN_PUMA: true
+    # Optimisations pour VPS M
+    WEB_CONCURRENCY: 2
+    JOB_CONCURRENCY: 1
+    RAILS_LOG_LEVEL: info
+    # Port production
+    PORT: 3000
+    RAILS_PORT: 3000
 
-# Configuration Puma directe (pas de Nginx)
-puma:
-  threads: 4
-  workers: 2
-  bind: 0.0.0.0:80
+# Volumes pour les logs et données (production)
+volumes:
+  - "circographe_production_storage:/rails/storage"
+  - "/srv/www/lecircographe_production/log:/app/log"
 
-# Health check
+# Bridge fingerprinted assets
+asset_path: /rails/public/assets
+
+# Configure the image builder
+builder:
+  arch: amd64
+
+# Optimisations pour VPS M (2 vCPU, 4GB RAM)
+traefik:
+  options:
+    memory: 256Mi
+    cpu: 200m
+  # Labels pour distinguer prod de staging
+  labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.circographe-production.rule=Host(`lecircographe.fr`)"
+    - "traefik.http.routers.circographe-production.priority=200"
+    - "traefik.http.services.circographe-production.loadbalancer.server.port=3000"
+
+# Health check optimisé pour production
 healthcheck:
   path: /health
-  port: 80
+  port: 3000
   max_attempts: 10
   interval: 10s
-
-# Limites de ressources adaptées au VPS M
-limits:
-  memory: 512Mi
-  cpu: 500m
-
-# Volumes pour les logs et données
-volumes:
-  - /var/log/circographe:/app/log
-  - /var/lib/circographe:/app/storage
-
-# Configuration SSL avec Let's Encrypt
-ssl:
-  cert_path: /etc/letsencrypt/live/lecircographe.fr/fullchain.pem
-  key_path: /etc/letsencrypt/live/lecircographe.fr/privkey.pem
+  timeout: 5s

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -6,6 +6,9 @@ image: ghcr.io/lecircographe-asso/circographe:staging
 servers:
   - <%= ENV['STAGING_SERVER_IP'] %>
 
+# Ports pour éviter conflits avec prod
+port: 3001
+
 # Configuration SSH pour Kamal
 ssh:
   user: deploy
@@ -29,8 +32,15 @@ env:
     STAGING_PASSWORD: <%= ENV['STAGING_PASSWORD'] %>
     RAILS_SERVE_STATIC_FILES: true
     SOLID_QUEUE_IN_PUMA: true
+    # Optimisations pour VPS M
+    WEB_CONCURRENCY: 2
+    JOB_CONCURRENCY: 1
+    RAILS_LOG_LEVEL: info
+    # Ports staging pour éviter conflits
+    PORT: 3001
+    RAILS_PORT: 3001
 
-# Volumes pour les logs et données
+# Volumes pour les logs et données (staging)
 volumes:
   - "circographe_staging_storage:/rails/storage"
   - "/srv/www/lecircographe_staging/log:/app/log"
@@ -41,3 +51,23 @@ asset_path: /rails/public/assets
 # Configure the image builder
 builder:
   arch: amd64
+
+# Optimisations pour VPS M (2 vCPU, 4GB RAM)
+traefik:
+  options:
+    memory: 128Mi
+    cpu: 100m
+  # Labels pour distinguer staging de prod
+  labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.circographe-staging.rule=Host(`staging.lecircographe.fr`)"
+    - "traefik.http.routers.circographe-staging.priority=100"
+    - "traefik.http.services.circographe-staging.loadbalancer.server.port=3001"
+
+# Health check optimisé pour staging
+healthcheck:
+  path: /health
+  port: 3001
+  max_attempts: 5
+  interval: 30s
+  timeout: 10s

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -44,14 +44,17 @@ env:
     # JOB_CONCURRENCY: 3
 
     # Set number of cores available to the application on each server (default: 1).
-    # WEB_CONCURRENCY: 2
+    WEB_CONCURRENCY: 2
 
-    # Match this to any external database server to configure Active Record correctly
-    # Use circographe-db for a db accessory server on same machine via local kamal docker network.
-    # DB_HOST: 192.168.0.2
+    # Set number of processes dedicated to Solid Queue (default: 1)
+    JOB_CONCURRENCY: 1
 
     # Log everything from Rails
-    # RAILS_LOG_LEVEL: debug
+    RAILS_LOG_LEVEL: info
+    
+    # Rails environment
+    RAILS_ENV: production
+    RAILS_SERVE_STATIC_FILES: true
 
 # Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
 # "bin/kamal logs -r job" will tail logs from the first server in the job section.
@@ -88,8 +91,9 @@ builder:
   #   - RAILS_MASTER_KEY
 
 # Use a different ssh user than root
-# ssh:
-#   user: app
+ssh:
+  user: deploy
+  key: <%= ENV['SSH_PRIVATE_KEY'] %>
 
 # Use accessory services (secrets come from .kamal/secrets).
 # accessories:


### PR DESCRIPTION
Optimizations for VPS Ionos Linux M:
- Separate ports: staging (3001), production (3000)
- Proper domains: staging.lecircographe.fr and lecircographe.fr
- Resource limits optimized for 2 vCPU, 4GB RAM
- Traefik labels for routing
- Health checks configured
- Builder arch set to amd64