### PR TITLE
fix: update Kamal configs to v2 syntax

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -4,15 +4,14 @@ image: ghcr.io/lecircographe-asso/circographe:latest
 
 # Serveur VPS Ionos
 servers:
-  - <%= ENV['PRODUCTION_SERVER_IP'] %>
+  web:
+    hosts:
+      - <%= ENV['PRODUCTION_SERVER_IP'] %>
 
 # Configuration SSH pour Kamal
 ssh:
   user: deploy
   key: <%= ENV['SSH_PRIVATE_KEY'] %>
-
-# Port production (différent de staging)
-port: 3000
 
 # Credentials for your image host
 registry:
@@ -20,6 +19,11 @@ registry:
   username: LeCircographe-asso
   password:
     - KAMAL_REGISTRY_PASSWORD
+
+# Proxy configuration pour production avec Traefik
+proxy:
+  ssl: true
+  host: lecircographe.fr
 
 # Variables d'environnement production
 env:
@@ -34,9 +38,6 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
-    # Port production
-    PORT: 3000
-    RAILS_PORT: 3000
 
 # Volumes pour les logs et données (production)
 volumes:
@@ -49,23 +50,3 @@ asset_path: /rails/public/assets
 # Configure the image builder
 builder:
   arch: amd64
-
-# Optimisations pour VPS M (2 vCPU, 4GB RAM)
-traefik:
-  options:
-    memory: 256Mi
-    cpu: 200m
-  # Labels pour distinguer prod de staging
-  labels:
-    - "traefik.enable=true"
-    - "traefik.http.routers.circographe-production.rule=Host(`lecircographe.fr`)"
-    - "traefik.http.routers.circographe-production.priority=200"
-    - "traefik.http.services.circographe-production.loadbalancer.server.port=3000"
-
-# Health check optimisé pour production
-healthcheck:
-  path: /health
-  port: 3000
-  max_attempts: 10
-  interval: 10s
-  timeout: 5s

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -4,10 +4,9 @@ image: ghcr.io/lecircographe-asso/circographe:staging
 
 # Serveur VPS Ionos
 servers:
-  - <%= ENV['STAGING_SERVER_IP'] %>
-
-# Ports pour éviter conflits avec prod
-port: 3001
+  web:
+    hosts:
+      - <%= ENV['STAGING_SERVER_IP'] %>
 
 # Configuration SSH pour Kamal
 ssh:
@@ -20,6 +19,11 @@ registry:
   username: LeCircographe-asso
   password:
     - KAMAL_REGISTRY_PASSWORD
+
+# Proxy configuration pour staging avec Traefik
+proxy:
+  ssl: true
+  host: staging.lecircographe.fr
 
 # Variables d'environnement staging
 env:
@@ -36,9 +40,6 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
-    # Ports staging pour éviter conflits
-    PORT: 3001
-    RAILS_PORT: 3001
 
 # Volumes pour les logs et données (staging)
 volumes:
@@ -51,23 +52,3 @@ asset_path: /rails/public/assets
 # Configure the image builder
 builder:
   arch: amd64
-
-# Optimisations pour VPS M (2 vCPU, 4GB RAM)
-traefik:
-  options:
-    memory: 128Mi
-    cpu: 100m
-  # Labels pour distinguer staging de prod
-  labels:
-    - "traefik.enable=true"
-    - "traefik.http.routers.circographe-staging.rule=Host(`staging.lecircographe.fr`)"
-    - "traefik.http.routers.circographe-staging.priority=100"
-    - "traefik.http.services.circographe-staging.loadbalancer.server.port=3001"
-
-# Health check optimisé pour staging
-healthcheck:
-  path: /health
-  port: 3001
-  max_attempts: 5
-  interval: 30s
-  timeout: 10s


### PR DESCRIPTION
Update Kamal configuration files to use v2 syntax:
- Replace deprecated port/traefik/healthcheck with proxy
- Staging: proxy ssl + host staging.lecircographe.fr  
- Production: proxy ssl + host lecircographe.fr
- Updated servers format to web/hosts structure
- Traefik will handle SSL and routing automatically