### PR TITLE
fix: remove deprecated ssh key from Kamal v2

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -11,7 +11,6 @@ servers:
 # Configuration SSH pour Kamal
 ssh:
   user: deploy
-  key: <%= ENV['SSH_PRIVATE_KEY'] %>
 
 # Credentials for your image host
 registry:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -11,7 +11,6 @@ servers:
 # Configuration SSH pour Kamal
 ssh:
   user: deploy
-  key: <%= ENV['SSH_PRIVATE_KEY'] %>
 
 # Credentials for your image host
 registry:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -93,7 +93,6 @@ builder:
 # Use a different ssh user than root
 ssh:
   user: deploy
-  key: <%= ENV['SSH_PRIVATE_KEY'] %>
 
 # Use accessory services (secrets come from .kamal/secrets).
 # accessories:


### PR DESCRIPTION
Remove ssh.key from configuration files - Kamal 2 uses SSH agent