### PR TITLE
fix: remove duplicate ghcr.io from image names

### DIFF
--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -1,6 +1,6 @@
 # Configuration Kamal pour Production - VPS Ionos Linux M
 service: circographe-production
-image: ghcr.io/lecircographe-asso/circographe:latest
+image: lecircographe-asso/circographe:latest
 
 # Serveur VPS Ionos
 servers:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,6 +1,6 @@
 # Configuration Kamal pour Staging - VPS Ionos Linux M
 service: circographe-staging
-image: ghcr.io/lecircographe-asso/circographe:staging
+image: lecircographe-asso/circographe:staging
 
 # Serveur VPS Ionos
 servers:


### PR DESCRIPTION
Fix Docker tag format - registry server is already defined in registry config