### PR TITLE
fix: remove SECRET_KEY_BASE from Kamal secrets

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -28,7 +28,6 @@ proxy:
 env:
   secret:
     - RAILS_MASTER_KEY
-    - SECRET_KEY_BASE
   clear:
     RAILS_ENV: staging
     STAGING_MODE: true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,7 +3,7 @@ Rails.application.configure do
   # Use the default credentials secret_key_base for staging
   # Rails will use config/credentials.yml.enc with RAILS_MASTER_KEY
   config.secret_key_base = Rails.application.credentials.secret_key_base
-  
+
   # Environnement
   config.cache_classes = true
   config.eager_load = true


### PR DESCRIPTION
Rails automatically loads secret_key_base from credentials.yml.enc using RAILS_MASTER_KEY. No need to declare it separately in Kamal secrets.