### PR TITLE
fix: export RAILS_MASTER_KEY for Kamal deployment

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -93,6 +93,10 @@ jobs:
         # Export SSH key path for Kamal
         export SSH_PRIVATE_KEY="$HOME/.ssh/deploy_key"
         
+        # Export environment variables for Kamal
+        export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
+        export STAGING_PASSWORD="$STAGING_PASSWORD"
+        
         # Deploy with Kamal
         kamal deploy -c config/deploy.staging.yml
         

--- a/.github/workflows/05-prod-deploy.yml
+++ b/.github/workflows/05-prod-deploy.yml
@@ -94,6 +94,9 @@ jobs:
         # Export SSH key path for Kamal
         export SSH_PRIVATE_KEY="$HOME/.ssh/deploy_key"
         
+        # Export environment variables for Kamal
+        export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
+        
         # Deploy with Kamal
         kamal deploy -c config/deploy.production.yml
         


### PR DESCRIPTION
Kamal needs environment variables to be exported to inject them into containers. This fixes the 'Missing secret_key_base for staging environment' error.