### PR TITLE
fix: add SECRET_KEY_BASE as Kamal secret for staging

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -85,6 +85,7 @@ jobs:
       env:
         STAGING_SERVER_IP: ${{ vars.STAGING_SERVER_IP }}
         RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
         KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         STAGING_PASSWORD: ${{ secrets.STAGING_PASSWORD }}
       run: |
@@ -95,6 +96,7 @@ jobs:
         
         # Export environment variables for Kamal
         export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
+        export SECRET_KEY_BASE="$SECRET_KEY_BASE"
         export STAGING_PASSWORD="$STAGING_PASSWORD"
         
         # Deploy with Kamal

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -28,6 +28,7 @@ proxy:
 env:
   secret:
     - RAILS_MASTER_KEY
+    - SECRET_KEY_BASE
   clear:
     RAILS_ENV: staging
     STAGING_MODE: true


### PR DESCRIPTION
Rails needs SECRET_KEY_BASE to be explicitly set when credentials can't be decrypted. This provides a fallback when RAILS_MASTER_KEY is not available in the container.