### PR TITLE
fix: add kamal secrets setup before deployment

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -99,6 +99,10 @@ jobs:
         export SECRET_KEY_BASE="$SECRET_KEY_BASE"
         export STAGING_PASSWORD="$STAGING_PASSWORD"
         
+        # Set up Kamal secrets on the server
+        echo "🔐 Setting up Kamal secrets..."
+        kamal secrets setup -c config/deploy.staging.yml
+        
         # Deploy with Kamal
         kamal deploy -c config/deploy.staging.yml
         

--- a/.github/workflows/05-prod-deploy.yml
+++ b/.github/workflows/05-prod-deploy.yml
@@ -97,6 +97,10 @@ jobs:
         # Export environment variables for Kamal
         export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
         
+        # Set up Kamal secrets on the server
+        echo "🔐 Setting up Kamal secrets..."
+        kamal secrets setup -c config/deploy.production.yml
+        
         # Deploy with Kamal
         kamal deploy -c config/deploy.production.yml
         


### PR DESCRIPTION
Kamal 2 requires secrets to be set up on the server before deployment. This ensures SECRET_KEY_BASE and other secrets are available in .kamal/secrets.