### PR TITLE
fix: correct kamal secrets command syntax

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -101,7 +101,7 @@ jobs:
         
         # Set up Kamal secrets on the server
         echo "🔐 Setting up Kamal secrets..."
-        kamal secrets setup -c config/deploy.staging.yml
+        kamal secrets -c config/deploy.staging.yml
         
         # Deploy with Kamal
         kamal deploy -c config/deploy.staging.yml

--- a/.github/workflows/05-prod-deploy.yml
+++ b/.github/workflows/05-prod-deploy.yml
@@ -99,7 +99,7 @@ jobs:
         
         # Set up Kamal secrets on the server
         echo "🔐 Setting up Kamal secrets..."
-        kamal secrets setup -c config/deploy.production.yml
+        kamal secrets -c config/deploy.production.yml
         
         # Deploy with Kamal
         kamal deploy -c config/deploy.production.yml


### PR DESCRIPTION
In Kamal 2, the command is 'kamal secrets' not 'kamal secrets setup'.