### PR TITLE
fix: create .kamal/secrets file locally in workflow

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -99,9 +99,14 @@ jobs:
         export SECRET_KEY_BASE="$SECRET_KEY_BASE"
         export STAGING_PASSWORD="$STAGING_PASSWORD"
         
-        # Set up Kamal secrets on the server
-        echo "🔐 Setting up Kamal secrets..."
-        kamal secrets -c config/deploy.staging.yml
+        # Create .kamal/secrets file for staging
+        echo "🔐 Creating Kamal secrets file..."
+        mkdir -p .kamal
+        cat > .kamal/secrets << EOF
+RAILS_MASTER_KEY=$RAILS_MASTER_KEY
+SECRET_KEY_BASE=$SECRET_KEY_BASE
+STAGING_PASSWORD=$STAGING_PASSWORD
+EOF
         
         # Deploy with Kamal
         kamal deploy -c config/deploy.staging.yml

--- a/.github/workflows/05-prod-deploy.yml
+++ b/.github/workflows/05-prod-deploy.yml
@@ -97,9 +97,12 @@ jobs:
         # Export environment variables for Kamal
         export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
         
-        # Set up Kamal secrets on the server
-        echo "🔐 Setting up Kamal secrets..."
-        kamal secrets -c config/deploy.production.yml
+        # Create .kamal/secrets file for production
+        echo "🔐 Creating Kamal secrets file..."
+        mkdir -p .kamal
+        cat > .kamal/secrets << EOF
+RAILS_MASTER_KEY=$RAILS_MASTER_KEY
+EOF
         
         # Deploy with Kamal
         kamal deploy -c config/deploy.production.yml


### PR DESCRIPTION
Kamal 2 reads secrets from .kamal/secrets file locally during deployment. This creates the secrets file with GitHub secrets before running kamal deploy.