### PR TITLE
fix: add port 3001 to proxy configuration in staging

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -23,6 +23,7 @@ registry:
 proxy:
   ssl: true
   host: staging.lecircographe.fr
+  port: 3001
 
 # Variables d'environnement staging
 env:


### PR DESCRIPTION
The application listens on port 3001 but Kamal was trying to healthcheck on port 80. This should fix the 'target failed to become healthy within configured timeout' error.