### PR TITLE
Deploy: Fix Kamal 2 port configuration and add verbose logging

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -16,6 +16,11 @@ jobs:
     environment:
       name: staging
       url: https://staging.lecircographe.fr
+    
+    env:
+      # Enable debug logging for GitHub Actions
+      ACTIONS_STEP_DEBUG: true
+      ACTIONS_RUNNER_DEBUG: true
       
     steps:
     - name: Validate Environment Variables
@@ -211,9 +216,12 @@ jobs:
         echo "Testing GHCR login..."
         echo "$KAMAL_REGISTRY_PASSWORD" | docker login ghcr.io -u ${{ github.actor }} --password-stdin || echo "❌ GHCR login failed"
         
-        # === STEP 7: Kamal Deploy ===
-        echo "🚀 STEP 7: Starting Kamal Deployment"
-        echo "Running: kamal deploy -c config/deploy.staging.yml --verbose"
+          # === STEP 7: Kamal Deploy ===
+          echo "🚀 STEP 7: Starting Kamal Deployment"
+          echo "Running: kamal deploy -c config/deploy.staging.yml --verbose --debug"
+          echo "Debug environment variables:"
+          echo "ACTIONS_STEP_DEBUG: $ACTIONS_STEP_DEBUG"
+          echo "ACTIONS_RUNNER_DEBUG: $ACTIONS_RUNNER_DEBUG"
         
         # Export all environment variables for Kamal
         export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
@@ -221,13 +229,14 @@ jobs:
         export STAGING_PASSWORD="$STAGING_PASSWORD"
         export KAMAL_REGISTRY_PASSWORD="$KAMAL_REGISTRY_PASSWORD"
         
-        # Deploy with maximum verbosity
-        kamal deploy -c config/deploy.staging.yml --verbose || {
-          echo "❌ Kamal deployment failed!"
-          echo "🔍 Checking server logs..."
-          ssh -i ~/.ssh/deploy_key deploy@$STAGING_SERVER_IP "docker ps -a" || echo "Cannot connect to server"
-          exit 1
-        }
+          # Deploy with maximum verbosity and debug logging
+          echo "🚀 Starting Kamal deployment with debug logging..."
+          kamal deploy -c config/deploy.staging.yml --verbose --debug || {
+            echo "❌ Kamal deployment failed!"
+            echo "🔍 Checking server logs..."
+            ssh -i ~/.ssh/deploy_key deploy@$STAGING_SERVER_IP "docker ps -a" || echo "Cannot connect to server"
+            exit 1
+          }
         
     - name: Notify staging deployment
       run: |

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -23,6 +23,7 @@ registry:
 proxy:
   ssl: true
   host: lecircographe.fr
+  app_port: 80
 
 # Variables d'environnement production
 env:
@@ -37,6 +38,9 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
+    # Port production - Rails écoute sur 80
+    PORT: 80
+    RAILS_PORT: 80
 
 # Volumes pour les logs et données (production)
 volumes:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -41,6 +41,9 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
+    # Port - Rails doit écouter sur port 80 pour Kamal
+    PORT: 80
+    RAILS_PORT: 80
 
 # Volumes pour les logs et données (staging)
 volumes:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -23,7 +23,7 @@ registry:
 proxy:
   ssl: true
   host: staging.lecircographe.fr
-  port: 3001
+  app_port: 3001
 
 # Variables d'environnement staging
 env:
@@ -41,9 +41,9 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
-    # Port - Rails doit écouter sur port 80 pour Kamal
-    PORT: 80
-    RAILS_PORT: 80
+    # Port staging - Rails écoute sur 3001
+    PORT: 3001
+    RAILS_PORT: 3001
 
 # Volumes pour les logs et données (staging)
 volumes:


### PR DESCRIPTION
### Changes
- Configure staging to use port 3001 with app_port
- Configure production to use port 80 with app_port
- Add verbose logging (ACTIONS_STEP_DEBUG, ACTIONS_RUNNER_DEBUG)
- Add --debug flag to kamal deploy for maximum verbosity

### Testing
Ready to deploy to staging with enhanced debugging.