### PR TITLE
fix: Kamal 2 port configuration and Docker permissions

### DIFF
--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -216,12 +216,11 @@ jobs:
         echo "Testing GHCR login..."
         echo "$KAMAL_REGISTRY_PASSWORD" | docker login ghcr.io -u ${{ github.actor }} --password-stdin || echo "❌ GHCR login failed"
         
-          # === STEP 7: Kamal Deploy ===
-          echo "🚀 STEP 7: Starting Kamal Deployment"
-          echo "Running: kamal deploy -c config/deploy.staging.yml --verbose"
-          echo "Debug environment variables:"
-          echo "ACTIONS_STEP_DEBUG: $ACTIONS_STEP_DEBUG"
-          echo "ACTIONS_RUNNER_DEBUG: $ACTIONS_RUNNER_DEBUG"
+        # === STEP 7: Kamal Deploy ===
+        echo "🚀 STEP 7: Starting Kamal Deployment"
+        echo "Debug environment variables:"
+        echo "ACTIONS_STEP_DEBUG: $ACTIONS_STEP_DEBUG"
+        echo "ACTIONS_RUNNER_DEBUG: $ACTIONS_RUNNER_DEBUG"
         
         # Export all environment variables for Kamal
         export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
@@ -229,9 +228,8 @@ jobs:
         export STAGING_PASSWORD="$STAGING_PASSWORD"
         export KAMAL_REGISTRY_PASSWORD="$KAMAL_REGISTRY_PASSWORD"
         
-          # Deploy with maximum verbosity
-          echo "🚀 Starting Kamal deployment with verbose logging..."
-          kamal deploy -c config/deploy.staging.yml --verbose || {
+        # Deploy with verbose logging
+        kamal deploy -c config/deploy.staging.yml --verbose || {
             echo "❌ Kamal deployment failed!"
             echo "🔍 Checking server logs..."
             ssh -i ~/.ssh/deploy_key deploy@$STAGING_SERVER_IP "docker ps -a" || echo "Cannot connect to server"

--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -16,6 +16,11 @@ jobs:
     environment:
       name: staging
       url: https://staging.lecircographe.fr
+    
+    env:
+      # Enable debug logging for GitHub Actions
+      ACTIONS_STEP_DEBUG: true
+      ACTIONS_RUNNER_DEBUG: true
       
     steps:
     - name: Validate Environment Variables
@@ -211,9 +216,12 @@ jobs:
         echo "Testing GHCR login..."
         echo "$KAMAL_REGISTRY_PASSWORD" | docker login ghcr.io -u ${{ github.actor }} --password-stdin || echo "❌ GHCR login failed"
         
-        # === STEP 7: Kamal Deploy ===
-        echo "🚀 STEP 7: Starting Kamal Deployment"
-        echo "Running: kamal deploy -c config/deploy.staging.yml --verbose"
+          # === STEP 7: Kamal Deploy ===
+          echo "🚀 STEP 7: Starting Kamal Deployment"
+          echo "Running: kamal deploy -c config/deploy.staging.yml --verbose --debug"
+          echo "Debug environment variables:"
+          echo "ACTIONS_STEP_DEBUG: $ACTIONS_STEP_DEBUG"
+          echo "ACTIONS_RUNNER_DEBUG: $ACTIONS_RUNNER_DEBUG"
         
         # Export all environment variables for Kamal
         export RAILS_MASTER_KEY="$RAILS_MASTER_KEY"
@@ -221,13 +229,14 @@ jobs:
         export STAGING_PASSWORD="$STAGING_PASSWORD"
         export KAMAL_REGISTRY_PASSWORD="$KAMAL_REGISTRY_PASSWORD"
         
-        # Deploy with maximum verbosity
-        kamal deploy -c config/deploy.staging.yml --verbose || {
-          echo "❌ Kamal deployment failed!"
-          echo "🔍 Checking server logs..."
-          ssh -i ~/.ssh/deploy_key deploy@$STAGING_SERVER_IP "docker ps -a" || echo "Cannot connect to server"
-          exit 1
-        }
+          # Deploy with maximum verbosity and debug logging
+          echo "🚀 Starting Kamal deployment with debug logging..."
+          kamal deploy -c config/deploy.staging.yml --verbose --debug || {
+            echo "❌ Kamal deployment failed!"
+            echo "🔍 Checking server logs..."
+            ssh -i ~/.ssh/deploy_key deploy@$STAGING_SERVER_IP "docker ps -a" || echo "Cannot connect to server"
+            exit 1
+          }
         
     - name: Notify staging deployment
       run: |

--- a/.github/workflows/03-staging-deploy.yml
+++ b/.github/workflows/03-staging-deploy.yml
@@ -218,7 +218,7 @@ jobs:
         
           # === STEP 7: Kamal Deploy ===
           echo "🚀 STEP 7: Starting Kamal Deployment"
-          echo "Running: kamal deploy -c config/deploy.staging.yml --verbose --debug"
+          echo "Running: kamal deploy -c config/deploy.staging.yml --verbose"
           echo "Debug environment variables:"
           echo "ACTIONS_STEP_DEBUG: $ACTIONS_STEP_DEBUG"
           echo "ACTIONS_RUNNER_DEBUG: $ACTIONS_RUNNER_DEBUG"
@@ -229,9 +229,9 @@ jobs:
         export STAGING_PASSWORD="$STAGING_PASSWORD"
         export KAMAL_REGISTRY_PASSWORD="$KAMAL_REGISTRY_PASSWORD"
         
-          # Deploy with maximum verbosity and debug logging
-          echo "🚀 Starting Kamal deployment with debug logging..."
-          kamal deploy -c config/deploy.staging.yml --verbose --debug || {
+          # Deploy with maximum verbosity
+          echo "🚀 Starting Kamal deployment with verbose logging..."
+          kamal deploy -c config/deploy.staging.yml --verbose || {
             echo "❌ Kamal deployment failed!"
             echo "🔍 Checking server logs..."
             ssh -i ~/.ssh/deploy_key deploy@$STAGING_SERVER_IP "docker ps -a" || echo "Cannot connect to server"

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ COPY --from=build /rails /rails
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    mkdir -p /app/log && \
+    chown -R rails:rails db log storage tmp /app/log
 USER 1000:1000
 
 # Entrypoint prepares the database.

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -19,11 +19,12 @@ registry:
   password:
     - KAMAL_REGISTRY_PASSWORD
 
-# Proxy configuration pour production avec Traefik
+# Proxy configuration pour production (kamal-proxy avec Let's Encrypt auto)
 proxy:
   ssl: true
   host: lecircographe.fr
-  app_port: 80
+  # app_port: 80 (défaut, app écoute sur port 80 dans le conteneur)
+  # SSL géré automatiquement par kamal-proxy via Let's Encrypt
 
 # Variables d'environnement production
 env:
@@ -38,9 +39,6 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
-    # Port production - Rails écoute sur 80
-    PORT: 80
-    RAILS_PORT: 80
 
 # Volumes pour les logs et données (production)
 volumes:

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -23,6 +23,7 @@ registry:
 proxy:
   ssl: true
   host: lecircographe.fr
+  app_port: 80
 
 # Variables d'environnement production
 env:
@@ -37,6 +38,9 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
+    # Port production - Rails écoute sur 80
+    PORT: 80
+    RAILS_PORT: 80
 
 # Volumes pour les logs et données (production)
 volumes:

--- a/config/deploy.production.yml
+++ b/config/deploy.production.yml
@@ -23,7 +23,7 @@ registry:
 proxy:
   ssl: true
   host: lecircographe.fr
-  # app_port: 80 (défaut, app écoute sur port 80 dans le conteneur)
+  app_port: 80  # ← PORT INTERNE de l'app dans le conteneur
   # SSL géré automatiquement par kamal-proxy via Let's Encrypt
 
 # Variables d'environnement production
@@ -32,11 +32,12 @@ env:
     - RAILS_MASTER_KEY
   clear:
     RAILS_ENV: production
+    PORT: 80  # ← FORCER Puma à écouter sur port 80
     PRODUCTION_MODE: true
     RAILS_SERVE_STATIC_FILES: true
     SOLID_QUEUE_IN_PUMA: true
     # Optimisations pour VPS M
-    WEB_CONCURRENCY: 2
+    WEB_CONCURRENCY: 0  # ← Single mode (pas de workers)
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
 

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -23,7 +23,7 @@ registry:
 proxy:
   ssl: true
   host: staging.lecircographe.fr
-  # app_port: 80 (défaut, app écoute sur port 80 dans le conteneur)
+  app_port: 80  # ← PORT INTERNE de l'app dans le conteneur
 
 # Variables d'environnement staging
 env:
@@ -32,13 +32,14 @@ env:
     - SECRET_KEY_BASE
   clear:
     RAILS_ENV: staging
+    PORT: 80  # ← FORCER Puma à écouter sur port 80
     STAGING_MODE: true
     STAGING_AUTH: true
     STAGING_PASSWORD: <%= ENV['STAGING_PASSWORD'] %>
     RAILS_SERVE_STATIC_FILES: true
     SOLID_QUEUE_IN_PUMA: true
     # Optimisations pour VPS M
-    WEB_CONCURRENCY: 2
+    WEB_CONCURRENCY: 0  # ← Single mode (pas de workers)
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
 

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -19,11 +19,11 @@ registry:
   password:
     - KAMAL_REGISTRY_PASSWORD
 
-# Proxy configuration pour staging avec Traefik
+# Proxy configuration pour staging (kamal-proxy avec Let's Encrypt auto)
 proxy:
   ssl: true
   host: staging.lecircographe.fr
-  app_port: 3001
+  # app_port: 80 (défaut, app écoute sur port 80 dans le conteneur)
 
 # Variables d'environnement staging
 env:
@@ -41,9 +41,6 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
-    # Port staging - Rails écoute sur 3001
-    PORT: 3001
-    RAILS_PORT: 3001
 
 # Volumes pour les logs et données (staging)
 volumes:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -41,6 +41,9 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
+    # Port - Rails doit écouter sur port 80 pour Kamal
+    PORT: 80
+    RAILS_PORT: 80
 
 # Volumes pour les logs et données (staging)
 volumes:

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -23,7 +23,7 @@ registry:
 proxy:
   ssl: true
   host: staging.lecircographe.fr
-  port: 3001
+  app_port: 3001
 
 # Variables d'environnement staging
 env:
@@ -41,9 +41,9 @@ env:
     WEB_CONCURRENCY: 2
     JOB_CONCURRENCY: 1
     RAILS_LOG_LEVEL: info
-    # Port - Rails doit écouter sur port 80 pour Kamal
-    PORT: 80
-    RAILS_PORT: 80
+    # Port staging - Rails écoute sur 3001
+    PORT: 3001
+    RAILS_PORT: 3001
 
 # Volumes pour les logs et données (staging)
 volumes:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,10 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Use the default credentials secret_key_base for production
+  # Rails will use config/credentials.yml.enc with RAILS_MASTER_KEY
+  config.secret_key_base = Rails.application.credentials.secret_key_base
+
   # Code is not reloaded between requests.
   config.enable_reloading = false
 
@@ -58,7 +62,10 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = {
+    host: "lecircographe.fr",
+    protocol: "https"
+  }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   config.action_mailer.smtp_settings = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -39,11 +39,8 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Staging specific
-  config.staging_mode = true
-
-  # Désactiver certaines fonctionnalités en staging
-  config.disable_payments = true
-  config.disable_emails = true
+  # Note: Custom configs comme staging_mode doivent être définies dans application.rb
+  # ou via des initializers si nécessaire
 
   # Logs spécifiques
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,6 +8,8 @@
 # You can control the number of workers using ENV["WEB_CONCURRENCY"]. You
 # should only set this value when you want to run 2 or more workers. The
 # default is already 1.
+# For VPS with limited resources, use single mode (WEB_CONCURRENCY=0)
+workers ENV.fetch("WEB_CONCURRENCY", 0)
 #
 # The ideal number of threads per worker depends both on how much time the
 # application spends waiting for IO operations and on how much you wish to

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,16 +37,5 @@ plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
 
-# Environment-specific server configuration
-if Rails.env.production?
-  # Production SSL configuration
-  ssl_bind "0.0.0.0", "443", {
-    key: ".cert/_.lecircographe.fr_private_key.key",
-    cert: ".cert/server_cert_chain.crt",
-    ssl_ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:...",
-    ssl_protocols: "TLSv1.2 TLSv1.3"
-  }
-else
-  # Development server binding (HTTP only)
-  bind "tcp://0.0.0.0:3000"
-end
+# Specify the `port` to listen on (defaults to 3000, configurable via PORT env var)
+port ENV.fetch("PORT", 3000)


### PR DESCRIPTION
## 🔧 Corrections critiques pour le déploiement staging

### Problèmes corrigés:
- ✅ **Port Puma**: Force l'écoute sur port 80 (PORT=80)
- ✅ **Permissions Docker**: Crée /app/log avec bonnes permissions  
- ✅ **Puma cluster**: Single mode pour VPS M (WEB_CONCURRENCY=0)
- ✅ **Syntaxe Kamal 2**: app_port au lieu de port
- ✅ **Environnements Rails**: Corrections staging.rb et production.rb

### Architecture finale:


### Tests attendus:
- [ ] Rails écoute sur port 80
- [ ] Plus d'erreurs de permissions logs
- [ ] Plus de warning cluster mode Puma
- [ ] Healthcheck réussi
- [ ] App accessible sur https://staging.lecircographe.fr

### Références:
- Analyse logs précédents: Rails écoutait sur 3000 au lieu de 80
- Erreurs permissions: /app/log/puma.stdout.log (Errno::EACCES)
- Warning: cluster mode avec 1 worker (misconfiguration)