### PR TITLE
debug: Enhanced Puma port debugging

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,7 +40,9 @@ plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
 
 # Specify the `port` to listen on (defaults to 3000, configurable via PORT env var)
+puts "🔍 PUMA DEBUG: Starting port configuration..."
+puts "🔍 PUMA DEBUG: ENV['PORT'] = #{ENV['PORT'].inspect}"
 port_value = ENV.fetch("PORT", 3000)
-puts "🔍 PUMA DEBUG: PORT env var = #{ENV['PORT'].inspect}"
 puts "🔍 PUMA DEBUG: Using port = #{port_value}"
 port port_value
+puts "🔍 PUMA DEBUG: Port configuration completed!"


### PR DESCRIPTION
## 🔍 Debug: Enhanced Puma Port Configuration

### Modifications:
Ajout de messages de debug dans `config/puma.rb` pour diagnostiquer le problème de port.

### Debug ajouté:
```ruby
puts "🔍 PUMA DEBUG: Starting port configuration..."
puts "🔍 PUMA DEBUG: ENV['PORT'] = #{ENV['PORT'].inspect}"
port_value = ENV.fetch("PORT", 3000)
puts "🔍 PUMA DEBUG: Using port = #{port_value}"
port port_value
puts "🔍 PUMA DEBUG: Port configuration completed!"
```

### Problème:
- kamal-proxy essaie de se connecter à port 3000
- Configuration Kamal spécifie `PORT: 80`
- Besoin de voir quelle valeur Puma reçoit réellement