### PR TITLE
fix: Exclude /up healthcheck from SSL redirect

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,8 +37,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Skip http-to-https redirect for the default health check endpoint (for kamal-proxy).
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -28,8 +28,9 @@ Rails.application.configure do
   config.assets.compile = false
   config.assets.digest = true
 
-  # Force SSL
+  # Force SSL (but exclude healthcheck for kamal-proxy)
   config.force_ssl = true
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Mailer
   config.action_mailer.perform_caching = false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,9 +40,5 @@ plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
 
 # Specify the `port` to listen on (defaults to 3000, configurable via PORT env var)
-puts "🔍 PUMA DEBUG: Starting port configuration..."
-puts "🔍 PUMA DEBUG: ENV['PORT'] = #{ENV['PORT'].inspect}"
-port_value = ENV.fetch("PORT", 3000)
-puts "🔍 PUMA DEBUG: Using port = #{port_value}"
-port port_value
-puts "🔍 PUMA DEBUG: Port configuration completed!"
+# Note: With Rails 8 + Thruster, Puma runs on 3000 and Thruster proxies on PORT (80)
+port ENV.fetch("PORT", 3000)

--- a/docs/DEPLOIEMENT.md
+++ b/docs/DEPLOIEMENT.md
@@ -1,0 +1,307 @@
+# 🚀 Guide Déploiement - Le Circographe
+
+**VPS**: Ionos Linux M - 82.165.63.129  
+**Stack**: Rails 8.0.3 + Kamal 2.7.0 + kamal-proxy + Thruster
+
+---
+
+## 🐛 Debug: Architecture Découverte
+
+### Architecture Réelle (Rails 8 + Thruster)
+```
+Internet (HTTPS)
+    ↓
+kamal-proxy:443 (SSL termination via Let's Encrypt)
+    ↓ HTTP
+Thruster:80 (Proxy Rails 8)
+    ↓ HTTP
+Puma:3000 (App Rails)
+```
+
+### Problème Initial Identifié
+❌ **Erreur**: `dial tcp [::1]:3000: connect: connection refused`
+
+### Investigation
+1. **Hypothèse initiale**: Puma n'écoute pas sur port 80
+   - ❌ FAUX: Puma écoute sur 3000 (normal avec Thruster)
+   
+2. **Découverte**: Rails 8 utilise Thruster
+   - ✅ Thruster écoute sur port 80 (configuré via `PORT=80`)
+   - ✅ Puma écoute sur port 3000 (par défaut)
+   - ✅ `kamal-proxy` se connecte bien au conteneur sur port 80
+
+3. **Problème réel**: Healthcheck retourne 301 au lieu de 200
+   - Les logs montrent: `GET /up HTTP/1.1" 301`
+   - Thruster ou Rails force une redirection HTTPS
+   - `kamal-proxy` teste en HTTP → échec du healthcheck
+
+### Solution
+Configurer Rails pour accepter les healthchecks HTTP (nécessaire pour kamal-proxy).
+
+---
+
+## 📋 Configuration
+
+### Kamal Staging (`config/deploy.staging.yml`)
+```yaml
+proxy:
+  ssl: true  # Let's Encrypt auto
+  host: staging.lecircographe.fr
+
+env:
+  secret: [RAILS_MASTER_KEY, SECRET_KEY_BASE]
+  clear:
+    RAILS_ENV: staging
+    WEB_CONCURRENCY: 2
+```
+
+### Kamal Production (`config/deploy.production.yml`)
+```yaml
+proxy:
+  ssl: true  # Let's Encrypt auto
+  host: lecircographe.fr
+
+env:
+  secret: [RAILS_MASTER_KEY]
+  clear:
+    RAILS_ENV: production
+    WEB_CONCURRENCY: 2
+```
+
+---
+
+## 🔐 Secrets GitHub (Organization)
+
+**Secrets:**
+- `RAILS_MASTER_KEY` - Rails credentials
+- `SECRET_KEY_BASE` - Rails secret  
+- `SSH_PRIVATE_KEY` - Clé SSH VPS
+- `STAGING_PASSWORD` - Password staging
+
+**Variables:**
+- `STAGING_SERVER_IP` = `82.165.63.129`
+- `PRODUCTION_SERVER_IP` = `82.165.63.129`
+
+---
+
+## 🌐 DNS Requis
+
+```
+staging.lecircographe.fr → 82.165.63.129
+lecircographe.fr → 82.165.63.129
+www.lecircographe.fr → lecircographe.fr
+```
+
+---
+
+## 🔧 VPS Setup (Une Fois)
+
+```bash
+# User deploy + Docker
+adduser deploy
+usermod -aG docker deploy
+curl -fsSL https://get.docker.com | sh
+
+# SSH key
+mkdir -p /home/deploy/.ssh
+# Copier votre clé publique dans authorized_keys
+chown -R deploy:deploy /home/deploy/.ssh
+
+# Firewall
+ufw allow 22/tcp   # SSH
+ufw allow 80/tcp   # HTTP
+ufw allow 443/tcp  # HTTPS
+ufw enable
+```
+
+---
+
+## 🚀 Déploiement
+
+### Staging
+```bash
+# PR dev → staging
+gh pr create --base staging --head dev
+gh pr merge --squash  # Auto-déploie via 03-staging-deploy.yml
+```
+
+### Production  
+```bash
+# Après validation staging
+gh workflow run "04 - Promote to Main" --field confirm_promote=PROMOTE
+```
+
+---
+
+## 🔍 Comment ça Marche
+
+### Architecture
+```
+Internet → kamal-proxy (80/443) → Conteneurs (port 80)
+           ├─ staging.lecircographe.fr [SSL auto]
+           └─ lecircographe.fr [SSL auto]
+```
+
+### Environnements Rails
+- **Development** (`development.rb`) → Dev local, port 3000
+- **Test** (`test.rb`) → Tests automatisés, base de données temporaire  
+- **Staging** (`staging.rb`) → Tests sur VPS, `staging.lecircographe.fr`
+- **Production** (`production.rb`) → Production réelle, `lecircographe.fr`
+
+**Note**: Chaque environnement a sa propre `secret_key_base` via `RAILS_MASTER_KEY`
+
+### kamal-proxy
+- **Un proxy unique** pour staging + prod
+- **SSL automatique** Let's Encrypt (renouvellement auto)
+- **Routing** par hostname (SNI)
+- **Zero-downtime** natif
+- **Healthcheck** GET /up (timeout 30s)
+
+### Les Conteneurs
+- Écoutent sur **port 80** (HTTP)
+- **Pas de config SSL** (géré par kamal-proxy)
+- Rails reçoit headers corrects (`X-Forwarded-Proto: https`)
+
+---
+
+## 📝 Logs
+
+### Configuration des Logs (déjà dans deploy.yml)
+```yaml
+# Les logs Docker sont automatiques avec rotation
+# Kamal ajoute par défaut:
+logging:
+  - "--log-opt"
+  - "max-size=10m"  # Max 10MB par fichier log
+
+# Logs applicatifs Rails → /app/log dans le conteneur
+volumes:
+  - "/srv/www/lecircographe_staging/log:/app/log"
+```
+
+### Accès aux Logs
+
+**Temps réel (streaming):**
+```bash
+# Staging
+kamal app logs -c config/deploy.staging.yml -f
+
+# Production
+kamal app logs -c config/deploy.production.yml -f
+
+# Avec filtre (ex: erreurs uniquement)
+kamal app logs -c config/deploy.staging.yml -f | grep ERROR
+```
+
+**Logs historiques:**
+```bash
+# 100 dernières lignes
+kamal app logs -c config/deploy.staging.yml --lines 100
+
+# Logs depuis 1h
+kamal app logs -c config/deploy.staging.yml --since 1h
+
+# Logs entre deux dates
+kamal app logs -c config/deploy.staging.yml --since "2025-10-11 10:00" --until "2025-10-11 12:00"
+```
+
+**Sur le VPS directement:**
+```bash
+# Logs Docker (stdout/stderr)
+ssh deploy@82.165.63.129 "docker logs circographe-staging-web-XXX"
+
+# Logs Rails (fichiers)
+ssh deploy@82.165.63.129 "tail -f /srv/www/lecircographe_staging/log/production.log"
+ssh deploy@82.165.63.129 "tail -f /srv/www/lecircographe_staging/log/staging.log"
+
+# Logs kamal-proxy
+ssh deploy@82.165.63.129 "docker logs kamal-proxy"
+```
+
+---
+
+## 🐛 Troubleshooting
+
+### Diagnostic Kamal
+```bash
+# Status de l'app (staging)
+kamal app status -c config/deploy.staging.yml
+
+# Logs en temps réel (staging)
+kamal app logs -c config/deploy.staging.yml -f
+
+# Logs des 100 dernières lignes
+kamal app logs -c config/deploy.staging.yml --lines 100
+
+# Status de l'app (production)
+kamal app status -c config/deploy.production.yml
+
+# Logs production
+kamal app logs -c config/deploy.production.yml -f
+```
+
+### Healthcheck échoue
+```bash
+# Via Kamal (recommandé)
+kamal app logs -c config/deploy.staging.yml --lines 50
+
+# Ou directement via SSH
+ssh deploy@82.165.63.129 "docker ps -a | grep circographe"
+ssh deploy@82.165.63.129 "docker logs circographe-staging-web-XXX"
+
+# App DOIT écouter sur port 80 (pas 3000!)
+```
+
+### Erreur SSL
+```bash
+# Vérifier DNS propagé
+dig staging.lecircographe.fr
+dig lecircographe.fr
+
+# Vérifier ports ouverts
+ssh deploy@82.165.63.129 "ufw status"
+
+# Logs proxy
+ssh deploy@82.165.63.129 "docker logs kamal-proxy"
+```
+
+### Commandes Utiles
+```bash
+# Redémarrer l'app
+kamal app restart -c config/deploy.staging.yml
+
+# Arrêter l'app
+kamal app stop -c config/deploy.staging.yml
+
+# Voir les conteneurs
+kamal app containers -c config/deploy.staging.yml
+
+# Version déployée
+kamal app version -c config/deploy.staging.yml
+
+# Exécuter une commande dans le conteneur
+kamal app exec -c config/deploy.staging.yml "bin/rails console"
+```
+
+---
+
+## ✅ Checklist
+
+**GitHub:**
+- [ ] Secrets organization OK
+- [ ] Variables organization OK
+
+**VPS:**
+- [ ] Docker installé
+- [ ] User `deploy` + SSH OK
+- [ ] Ports 22/80/443 ouverts
+- [ ] Test: `ssh deploy@82.165.63.129`
+
+**DNS:**
+- [ ] Records A configurés
+- [ ] DNS propagé (24-48h)
+
+---
+
+**Ref**: [Kamal 2 Docs](https://kamal-deploy.org/)
+


### PR DESCRIPTION
## 🎯 Solution Finale!

### Problème Résolu
Le healthcheck échouait car Rails force_ssl redirige TOUT en HTTPS (301), y compris `/up`.  
kamal-proxy teste en HTTP → 301 → échec.

### Architecture Découverte (Rails 8 + Thruster)
```
Internet (HTTPS)
    ↓
kamal-proxy:443 (SSL termination via Let's Encrypt)
    ↓ HTTP
Thruster:80 (Proxy Rails 8)
    ↓ HTTP
Puma:3000 (App Rails)
```

### Solution Appliquée
✅ **Exclusion de `/up` du force_ssl**
```ruby
config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
```

### Résultat Attendu
- 🎯 **Healthcheck HTTP sur `/up`** retourne 200 (plus de 301)
- 🎯 **kamal-proxy** peut vérifier la santé de l'app
- 🎯 **Tout le reste** est toujours forcé en HTTPS (sécurité maintenue)
- 🎯 **Déploiement réussi** avec SSL automatique via Let's Encrypt
- 🎯 **App accessible** sur https://staging.lecircographe.fr

### Changements
- `config/environments/staging.rb`: Ajout ssl_options  
- `config/environments/production.rb`: Décommenté ssl_options existant
- `config/puma.rb`: Nettoyé debug, ajouté note architecture
- `docs/DEPLOIEMENT.md`: Documenté découvertes et architecture

### Documentation
Tout le processus de debug est documenté dans `docs/DEPLOIEMENT.md`