### PR TITLE
feat: enhance hero section, add PWA install prompt, and mark demo con…

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server
+web: bin/rails server -b 0.0.0.0
 css: bin/rails tailwindcss:watch

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -28,6 +28,15 @@ if (typeof window.initFlowbite !== 'function') {
 
 document.addEventListener("turbo:load", () => {
     window.initFlowbite();
+    registerServiceWorker();
 });
 import "trix"
 import "@rails/actiontext"
+
+function registerServiceWorker() {
+  if (!("serviceWorker" in navigator)) return
+
+  navigator.serviceWorker.register("/service-worker").catch((error) => {
+    console.warn("Service worker registration failed:", error)
+  })
+}

--- a/app/javascript/controllers/pwa_install_controller.js
+++ b/app/javascript/controllers/pwa_install_controller.js
@@ -1,0 +1,101 @@
+import { Controller } from "@hotwired/stimulus"
+
+let deferredInstallPrompt = null
+
+export default class extends Controller {
+  static targets = ["container", "button", "status", "iosHelp"]
+
+  connect() {
+    this.beforeInstallPromptHandler = this.handleBeforeInstallPrompt.bind(this)
+    this.appInstalledHandler = this.handleAppInstalled.bind(this)
+
+    window.addEventListener("beforeinstallprompt", this.beforeInstallPromptHandler)
+    window.addEventListener("appinstalled", this.appInstalledHandler)
+
+    if (deferredInstallPrompt) {
+      this.showPromptReadyState()
+    } else if (this.isIosBrowser() && !this.isRunningStandalone()) {
+      this.showIosState()
+    }
+  }
+
+  disconnect() {
+    window.removeEventListener("beforeinstallprompt", this.beforeInstallPromptHandler)
+    window.removeEventListener("appinstalled", this.appInstalledHandler)
+  }
+
+  async install() {
+    if (deferredInstallPrompt) {
+      deferredInstallPrompt.prompt()
+      const { outcome } = await deferredInstallPrompt.userChoice
+
+      if (outcome === "accepted") {
+        this.setStatus("Installation lancée.")
+      } else {
+        this.setStatus("Installation annulée pour le moment.")
+      }
+
+      deferredInstallPrompt = null
+      this.hideButton()
+      return
+    }
+
+    if (this.isIosBrowser() && !this.isRunningStandalone()) {
+      this.showIosState(true)
+    }
+  }
+
+  handleBeforeInstallPrompt(event) {
+    event.preventDefault()
+    deferredInstallPrompt = event
+    this.showPromptReadyState()
+  }
+
+  handleAppInstalled() {
+    deferredInstallPrompt = null
+    this.containerTarget.hidden = false
+    this.hideButton()
+    this.hideIosHelp()
+    this.setStatus("Application installée. Tu peux maintenant la retrouver sur ton écran d'accueil.")
+  }
+
+  showPromptReadyState() {
+    this.containerTarget.hidden = false
+    this.hideIosHelp()
+    this.showButton("Installer l'application")
+    this.setStatus("Ajoute l'app pour retrouver rapidement les horaires et l'accès.")
+  }
+
+  showIosState(expanded = false) {
+    this.containerTarget.hidden = false
+    this.showButton("Voir comment l'installer")
+    this.iosHelpTarget.hidden = !expanded
+    this.setStatus("Sur iPhone, l'ajout passe par le menu Partager.")
+  }
+
+  showButton(label) {
+    this.buttonTarget.hidden = false
+    this.buttonTarget.textContent = label
+  }
+
+  hideButton() {
+    this.buttonTarget.hidden = true
+  }
+
+  hideIosHelp() {
+    this.iosHelpTarget.hidden = true
+  }
+
+  setStatus(message) {
+    this.statusTarget.textContent = message
+  }
+
+  isRunningStandalone() {
+    return window.matchMedia("(display-mode: standalone)").matches || window.navigator.standalone === true
+  }
+
+  isIosBrowser() {
+    const userAgent = window.navigator.userAgent || ""
+    return /iPad|iPhone|iPod/.test(userAgent)
+  }
+}

--- a/app/javascript/home_animations.js
+++ b/app/javascript/home_animations.js
@@ -5,6 +5,8 @@ document.addEventListener("turbo:load", initAnimations)
 
 function initAnimations () {
   const titleElement = document.getElementById("title")
+  const heroKicker = document.querySelector(".hero-kicker")
+  const heroIntro = document.querySelector(".hero-intro")
   const mainButton = document.querySelector(".main-button")
   const mainContent = document.getElementById("main-content")
   const scrollArrow = document.querySelector(".scroll-arrow-container")
@@ -20,7 +22,9 @@ function initAnimations () {
 
   gsapScoped(() => {
     if (prefersReducedMotion()) {
+      if (heroKicker) heroKicker.classList.remove("opacity-0")
       if (titleElement) titleElement.classList.remove("opacity-0")
+      if (heroIntro) heroIntro.classList.remove("opacity-0")
       if (mainButton) mainButton.classList.remove("opacity-0")
       if (mainContent) mainContent.classList.remove("opacity-0")
       if (map) map.classList.remove("opacity-0")
@@ -29,6 +33,15 @@ function initAnimations () {
     }
 
     const letters = buildLetterSpans(titleElement)
+    if (heroKicker) {
+      gsap.fromTo(
+        heroKicker,
+        { opacity: 0, y: -14 },
+        { opacity: 1, y: 0, duration: 0.45, ease: "power2.out",
+          onComplete: () => heroKicker.classList.remove("opacity-0") }
+      )
+    }
+
     if (letters.length) {
       gsap.set(letters, { opacity: 0 })
       gsap.to(letters, {
@@ -41,18 +54,27 @@ function initAnimations () {
       titleElement.classList.remove("opacity-0")
     }
 
+    if (heroIntro) {
+      gsap.fromTo(
+        heroIntro,
+        { opacity: 0, y: 18 },
+        { opacity: 1, y: 0, duration: 0.55, delay: 0.45, ease: "power2.out",
+          onComplete: () => heroIntro.classList.remove("opacity-0") }
+      )
+    }
+
     gsap.fromTo(
       mainButton,
-      { opacity: 0 },
-      { opacity: 1, duration: 0.5, delay: 1.5, ease: "power2.out",
+      { opacity: 0, y: 16 },
+      { opacity: 1, y: 0, duration: 0.5, delay: 1.1, ease: "power2.out",
         onComplete: () => mainButton.classList.remove("opacity-0") }
     )
 
     if (scrollArrow) {
       gsap.fromTo(
         scrollArrow,
-        { opacity: 0 },
-        { opacity: 1, duration: 0.5, delay: 1.8, ease: "power2.out",
+        { opacity: 0, y: 10 },
+        { opacity: 1, y: 0, duration: 0.5, delay: 1.35, ease: "power2.out",
           onComplete: () => scrollArrow.classList.remove("opacity-0") }
       )
     }
@@ -65,11 +87,13 @@ function initAnimations () {
     }, 4000)
 
     return () => {
+      if (heroKicker) heroKicker.classList.add("opacity-0")
       const t = document.getElementById("title")
       if (t && savedTitleText != null) {
         t.textContent = savedTitleText
         t.classList.add("opacity-0")
       }
+      if (heroIntro) heroIntro.classList.add("opacity-0")
     }
   }, scopeEl)
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,7 +1,14 @@
 <% content_for :title, "Le Circographe - Détail Événement" %>
 
     <div class="page-container-wide mb-12 fade-in">
-        <h1 class="text-4xl font-bold text-center text-black bg-white/95 py-6 mb-8 rounded-lg shadow-md"><%= @event.title %></h1>
+        <div class="space-y-3 mb-8">
+            <div class="flex justify-center">
+                <span class="inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-800">
+                    Démo UX/UI · événement fictif
+                </span>
+            </div>
+            <h1 class="text-4xl font-bold text-center text-black bg-white/95 py-6 rounded-lg shadow-md"><%= @event.title %></h1>
+        </div>
         
         <div class="surface-card bg-white/95 p-6 shadow-md">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -45,8 +52,11 @@
                         <% if current_user %>
                           <%= render "events/interest_button", event: @event, current_user: current_user %>
                         <% else %>
-                          <%= link_to "Je suis intéressé", new_session_path, 
+                          <%= link_to "Se connecter pour indiquer son intérêt", new_session_path,
                               class: "public-cta block w-full text-center" %>
+                          <p class="text-sm text-gray-600 text-center">
+                            Connexion requise pour cette action. Cette page événement est actuellement une démonstration d'interface.
+                          </p>
                         <% end %>
                         <%= button_to "Payer 10€", checkout_create_path(event_id: @event.id), method: :post, data: { turbo: "false" }, class: "public-cta w-full cursor-pointer" %>
                     </div>

--- a/app/views/home/_upcoming_events.html.erb
+++ b/app/views/home/_upcoming_events.html.erb
@@ -6,8 +6,8 @@
     <% event_time = upcoming_event.date&.in_time_zone(Time.zone) %>
 
   <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <div class="flex items-start gap-4">
-        <div class="flex flex-col items-center justify-center w-16 h-16 rounded-2xl bg-brand-primary/10 text-brand-primary font-semibold uppercase tracking-wider">
+        <div class="flex items-start gap-4">
+          <div class="flex flex-col items-center justify-center w-16 h-16 rounded-2xl bg-brand-primary/10 text-brand-primary font-semibold uppercase tracking-wider">
           <% if event_time.present? %>
             <span class="text-lg leading-none"><%= event_time.strftime("%d") %></span>
             <span class="text-xs"><%= event_time.strftime("%b") %></span>
@@ -17,13 +17,19 @@
           <% end %>
         </div>
         <div class="space-y-2">
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
             <span class="badge-accent">
               <i class="fas fa-calendar-alt mr-1"></i>
               Prochain événement
             </span>
+            <span class="inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-800">
+              Démo UX/UI
+            </span>
           </div>
           <h3 class="text-xl font-semibold text-gray-900 leading-snug"><%= upcoming_event.title %></h3>
+          <p class="text-xs font-medium uppercase tracking-[0.2em] text-amber-700">
+            Contenu fictif présenté pour la démonstration de l'interface.
+          </p>
           <% description = upcoming_event.middle_description.presence || upcoming_event.upper_description.presence || upcoming_event.description.presence %>
           <% if description.present? %>
             <p class="text-sm sm:text-base text-gray-600 line-clamp-3"><%= description %></p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,13 +2,21 @@
 <% content_for :background_image, "background.webp" %>
 
 <div class="relative w-full" data-home-animations-scope>
-  <section class="relative w-full min-h-[calc(100dvh-3.6rem)] sm:min-h-[calc(100dvh-4.2rem)] flex flex-col items-center justify-start px-4 sm:px-6 md:px-10 lg:px-12 pt-24 sm:pt-28 md:pt-[min(7.5rem,13vh)] pb-16 sm:pb-20 text-center">
+  <section class="relative w-full min-h-[calc(100dvh-3.6rem)] sm:min-h-[calc(100dvh-4.2rem)] flex flex-col items-center justify-start px-4 sm:px-6 md:px-10 lg:px-12 pt-[4.5rem] sm:pt-28 md:pt-[min(7.5rem,13vh)] pb-16 sm:pb-20 text-center">
     <div class="flex w-full max-w-full min-w-0 flex-col items-center gap-5 sm:gap-7 md:gap-8 -translate-y-5 sm:-translate-y-8">
+      <p class="hero-kicker opacity-0 text-xs font-semibold uppercase tracking-[0.38em] text-white/75 sm:text-sm">
+        Toulouse · Cirque · Atelier · Vie associative
+      </p>
       <h1 id="title" class="font-circographe w-full max-w-[min(100%,44rem)] min-w-0 whitespace-normal break-words text-[clamp(2.75rem,7vw+0.85rem,4.5rem)] font-bold text-white max-sm:tracking-[0.03em] tracking-[0.06em] md:tracking-[0.08em] leading-[1.08] max-sm:leading-[1.06] sm:leading-tight opacity-0 transition-opacity duration-500 [overflow-wrap:anywhere]">Le Circographe</h1>
+      <p class="hero-intro max-w-[min(100%,30rem)] text-pretty px-2 text-sm leading-6 text-white/90 opacity-0 sm:px-0 sm:text-base md:text-lg">
+        Un lieu vivant pour s'entraîner et se rencontrer.
+      </p>
 
-      <div class="main-button opacity-0 transition-opacity duration-500">
+      <div class="main-button flex flex-col items-center gap-3 opacity-0 transition-opacity duration-500 sm:flex-row">
       <%= link_to "Découvrir l'association", page_path('association'),
-                  class: "inline-flex items-center justify-center px-5 py-3 text-base font-semibold rounded-full border-2 border-white/85 bg-white/95 text-gray-900 shadow-md transition-colors duration-300 hover:bg-[#1F5C55] hover:text-white hover:border-[#1F5C55] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1F5C55] sm:px-8 sm:py-4 sm:text-lg md:text-xl" %>
+                  class: "inline-flex min-w-[15rem] items-center justify-center px-5 py-3 text-base font-semibold rounded-full border-2 border-white/85 bg-white/95 text-gray-900 shadow-md transition-colors duration-300 hover:bg-[#1F5C55] hover:text-white hover:border-[#1F5C55] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1F5C55] sm:px-8 sm:py-4 sm:text-lg" %>
+      <%= link_to "Voir les horaires", "#opening-hours",
+                  class: "inline-flex min-w-[15rem] items-center justify-center rounded-full border border-white/55 bg-white/10 px-5 py-3 text-base font-medium text-white backdrop-blur-sm transition-colors duration-300 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:px-8 sm:py-4 sm:text-lg" %>
       </div>
     </div>
 
@@ -33,6 +41,33 @@
             <div class="mt-4 sm:mt-7 bg-white/95 text-gray-900 rounded-[20px] shadow-xl p-4 sm:p-6">
               <%= render "shared/opening_hours", horaires: @opening_hours, bare: true, compact: true %>
             </div>
+
+            <section class="mt-4 rounded-[20px] border border-white/20 bg-white/10 p-4 text-left shadow-lg backdrop-blur-sm"
+                     data-controller="pwa-install"
+                     data-pwa-install-target="container"
+                     hidden>
+              <p class="text-xs uppercase tracking-[0.32em] text-white/70">Accès rapide</p>
+              <h3 class="mt-2 text-lg font-semibold text-white">Ajoute Le Circographe à ton écran d'accueil</h3>
+              <p class="mt-2 text-sm leading-6 text-white/85">
+                Pratique pour retrouver les horaires, l'accès et les infos utiles en un tap.
+              </p>
+              <div class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+                <button type="button"
+                        class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#194A45] transition-colors duration-300 hover:bg-[#F7F4EE]"
+                        data-action="pwa-install#install"
+                        data-pwa-install-target="button">
+                  Installer l'application
+                </button>
+                <p class="text-xs leading-5 text-white/70" data-pwa-install-target="status">
+                  Disponible quand ton navigateur autorise l'installation.
+                </p>
+              </div>
+              <div class="mt-4 rounded-2xl bg-white/12 p-3 text-sm leading-6 text-white/90"
+                   data-pwa-install-target="iosHelp"
+                   hidden>
+                Sur iPhone : ouvre le menu Partager puis choisis <strong>Sur l'écran d'accueil</strong>.
+              </div>
+            </section>
           </article>
 
           <div class="flex flex-col gap-5" data-gsap-reveal-item>
@@ -67,5 +102,3 @@
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.7);
   }
 </style>
-
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,11 @@
 <head>
     <title><%= content_for(:title) || t("layouts.application.title") %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="Le Circographe, lieu de cirque vivant, d'entraînement, de rencontres et d'ateliers à Toulouse.">
+    <meta name="theme-color" content="#1F5C55">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Circographe">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -70,7 +74,7 @@
     <header>
         <%= render 'shared/navbar' %>
     </header>
-    <div class="flex-grow bg-no-repeat bg-cover bg-center <%= 'parallax-bg' if controller_name == 'home' && action_name == 'index' %>" style="background-image: url('<%= asset_path(content_for(:background_image) || 'background.webp') %>'); background-attachment: fixed; background-position: center; background-repeat: no-repeat; background-size: cover;">
+    <div class="flex-grow bg-no-repeat bg-cover bg-center <%= 'parallax-bg' if controller_name == 'home' && action_name == 'index' %>" style="background-image: url('<%= asset_path(content_for(:background_image) || 'background.webp') %>'); background-position: center; background-repeat: no-repeat; background-size: cover;">
         <%= turbo_frame_tag ProfileSectionDomIds::FLASH_FRAME do %>
         <%= render 'shared/flash' %>
         <% end %>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,7 @@
 {
-  "name": "Circographe",
+  "id": "/",
+  "name": "Le Circographe",
+  "short_name": "Circographe",
   "icons": [
     {
       "src": "/icon.png",
@@ -14,9 +16,13 @@
     }
   ],
   "start_url": "/",
+  "display_override": ["standalone", "minimal-ui", "browser"],
   "display": "standalone",
   "scope": "/",
-  "description": "Circographe.",
-  "theme_color": "black",
-  "background_color": "black"
+  "orientation": "portrait-primary",
+  "lang": "fr",
+  "description": "Le Circographe, lieu de cirque vivant, d'entraînement, de rencontres et d'ateliers à Toulouse.",
+  "theme_color": "#1F5C55",
+  "background_color": "#F7F4EE",
+  "categories": ["sports", "education", "lifestyle"]
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -195,9 +195,6 @@
                                     <%= link_to t("views.shared.navbar.our_news"), page_path("news"), class: "flex items-center w-full py-4 font-medium text-left text-gray-900", data: { 'nav-active-target': 'link', 'nav-active-path': page_path('news'), 'nav-active-active-classes': 'nav-active-link' } %>
                                 </li>
                                 <li>
-                                    <%= link_to t("views.shared.navbar.blog_newsletters"), page_path("blog_newsletter"), class: "block" %>
-                                </li>
-                                <li>
                                     <%= link_to t("views.shared.navbar.photo_gallery"), page_path("gallery"), class: "block" %>
                                 </li>
                             </ul>
@@ -296,6 +293,9 @@
                         <%= t("views.shared.navbar.sign_up_disabled_reason") %>
                       </p>
                     <% end %>
+                    <p class="col-span-2 min-[844px]:hidden text-xs font-normal text-gray-600 leading-snug text-center px-1">
+                      La connexion fonctionne. Certaines sections publiques sont encore en chantier.
+                    </p>
                 </div>
                 <% end %>
             </div>


### PR DESCRIPTION
…tent

- Add hero-kicker tagline and hero-intro subtitle with staggered GSAP animations
- Add secondary "Voir les horaires" CTA and min-width to hero buttons
- Add PWA install prompt card on homepage (Stimulus pwa-install controller)
- Add service worker registration in application.js
- Improve PWA manifest: proper name, theme-color, lang, categories, display_override
- Add Apple/PWA meta tags and site description to layout head
- Add "Démo UX/UI" badges on events show and upcoming events partial
- Remove blog_newsletter nav link; add sign-in disclaimer in mobile auth panel
- Bind dev server to 0.0.0.0 in Procfile.dev for LAN access
- Remove background-attachment: fixed (parallax) from layout wrapper