### PR TITLE
fix: configure Active Storage service for staging environment

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,6 +41,9 @@ Rails.application.configure do
     protocol: "https"
   }
 
+  # Active Storage
+  config.active_storage.service = :local
+
   # Database
   config.active_record.dump_schema_after_migration = false
 


### PR DESCRIPTION
- Set Active Storage service to local in the staging environment configuration, ensuring proper file handling during development and testing.